### PR TITLE
update time and HUnit bounds

### DIFF
--- a/src/Data/Time/CalendarTime/CalendarTime.hs
+++ b/src/Data/Time/CalendarTime/CalendarTime.hs
@@ -14,7 +14,7 @@ module Data.Time.CalendarTime.CalendarTime
     ) 
   where
 
-import Data.Time
+import Data.Time hiding (calendarDay, calendarMonth, calendarYear)
 import Data.Time.Calendar.OrdinalDate
 import Data.Time.Calendar.Month
 import Data.Time.Calendar.WeekDay

--- a/tests/Tests.lhs
+++ b/tests/Tests.lhs
@@ -16,7 +16,7 @@ a local time instance has not been created yet, all the dates are converted
 into UTC.
 
 #if MIN_VERSION_time(1,5,0)
-> import Data.Time hiding (Monday, Sunday)
+> import Data.Time hiding (Monday, Sunday, January, September, October)
 #else
 > import Data.Time
 > import System.Locale (TimeLocale, defaultTimeLocale, rfc822DateFormat)

--- a/tests/Tests.lhs
+++ b/tests/Tests.lhs
@@ -16,7 +16,7 @@ a local time instance has not been created yet, all the dates are converted
 into UTC.
 
 #if MIN_VERSION_time(1,5,0)
-> import Data.Time
+> import Data.Time hiding (Monday, Sunday)
 #else
 > import Data.Time
 > import System.Locale (TimeLocale, defaultTimeLocale, rfc822DateFormat)

--- a/time-recurrence.cabal
+++ b/time-recurrence.cabal
@@ -84,7 +84,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
-                       time >= 1.4 && < 1.9,
+                       time >= 1.4 && < 1.10,
                        data-ordlist >= 0.4.5,
                        mtl >= 2.0 && < 2.3
 
@@ -101,7 +101,7 @@ Test-Suite test-time-recurrence
   main-is:              Tests.lhs
   ghc-options:          -Wall -fno-warn-name-shadowing -fno-warn-orphans
   build-depends:        base >= 4 && < 5,
-                        time >= 1.4 && < 1.9,
+                        time >= 1.4 && < 1.10,
                         data-ordlist >= 0.4.5,
                         mtl >= 2.0 && < 2.3,
                         test-framework >= 0.8,

--- a/time-recurrence.cabal
+++ b/time-recurrence.cabal
@@ -84,7 +84,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
-                       time >= 1.4 && < 1.10,
+                       time >= 1.4 && < 1.12,
                        data-ordlist >= 0.4.5,
                        mtl >= 2.0 && < 2.3
 
@@ -101,7 +101,7 @@ Test-Suite test-time-recurrence
   main-is:              Tests.lhs
   ghc-options:          -Wall -fno-warn-name-shadowing -fno-warn-orphans
   build-depends:        base >= 4 && < 5,
-                        time >= 1.4 && < 1.10,
+                        time >= 1.4 && < 1.12,
                         data-ordlist >= 0.4.5,
                         mtl >= 2.0 && < 2.3,
                         test-framework >= 0.8,

--- a/time-recurrence.cabal
+++ b/time-recurrence.cabal
@@ -84,9 +84,9 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
-                       time >= 1.4 && < 1.12,
+                       time >= 1.4 && < 1.13,
                        data-ordlist >= 0.4.5,
-                       mtl >= 2.0 && < 2.3
+                       mtl >= 2.0 && < 2.4
 
   Default-Language:    Haskell98
   -- Modules not exported by this package.
@@ -101,9 +101,9 @@ Test-Suite test-time-recurrence
   main-is:              Tests.lhs
   ghc-options:          -Wall -fno-warn-name-shadowing -fno-warn-orphans
   build-depends:        base >= 4 && < 5,
-                        time >= 1.4 && < 1.12,
+                        time >= 1.4 && < 1.13,
                         data-ordlist >= 0.4.5,
-                        mtl >= 2.0 && < 2.3,
+                        mtl >= 2.0 && < 2.4,
                         test-framework >= 0.8,
                         test-framework-hunit >= 0.3.0,
                         HUnit >= 1.2 && < 1.7,

--- a/time-recurrence.cabal
+++ b/time-recurrence.cabal
@@ -84,7 +84,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
-                       time >= 1.4 && < 1.6,
+                       time >= 1.4 && < 1.9,
                        data-ordlist >= 0.4.5,
                        mtl >= 2.0 && < 2.3
 
@@ -101,12 +101,12 @@ Test-Suite test-time-recurrence
   main-is:              Tests.lhs
   ghc-options:          -Wall -fno-warn-name-shadowing -fno-warn-orphans
   build-depends:        base >= 4 && < 5,
-                        time >= 1.4 && < 1.6,
+                        time >= 1.4 && < 1.9,
                         data-ordlist >= 0.4.5,
                         mtl >= 2.0 && < 2.3,
                         test-framework >= 0.8,
                         test-framework-hunit >= 0.3.0,
-                        HUnit >= 1.2 && < 1.4,
+                        HUnit >= 1.2 && < 1.7,
                         old-locale >= 1.0 && < 1.1
   other-modules:
     Data.Time.Recurrence


### PR DESCRIPTION
I've updated the bounds for `time` and `HUnit` to allow them to build with `lts-8.0`.

I have personally run the tests using `lts-8.0` and they all pass.

---

Time change log: https://github.com/haskell/time/blob/master/changelog.md

HUnit change log: https://github.com/hspec/HUnit/blob/master/CHANGELOG.md